### PR TITLE
Add parsing support for the file handle argument type

### DIFF
--- a/src/dbus_marshaller.erl
+++ b/src/dbus_marshaller.erl
@@ -748,6 +748,7 @@ unmarshal_type_code($r) -> struct;
 unmarshal_type_code($v) -> variant;
 unmarshal_type_code($e) -> dict_entry;
 unmarshal_type_code($a) -> array;
+unmarshal_type_code($h) -> file_descriptor;
 unmarshal_type_code(_C) -> throw({bad_type_code, _C}).
 
 


### PR DESCRIPTION
systemd now returns methods with arguments of type `h`, signifying file descriptors. This causes parsing errors during the unmarshalling of the introspection XML output.

This PR adds support for _parsing_ such arguments, but does not add support for actually calling methods with a file descriptor.

ADO 428659